### PR TITLE
Fixed the below 2 issues.

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,19 @@ async function loadApp() {
   provider = new ethers.providers.Web3Provider(window.ethereum, "any");
   signer = provider.getSigner();
   if (!signer) window.location.reload();
-  await provider.send("eth_requestAccounts", []);
+  await requestAccounts();
   processAction();
+}
+
+async function requestAccounts() {
+  const p1 = provider.send("eth_requestAccounts", []);
+  const p2 = new Promise((_r, rej) => setTimeout(() => rej("timed out"), 20000)); // timeout of 20 seconds
+
+  try {
+    await Promise.race([p1, p2]);
+  } catch (error) {
+    window.location.reload();
+  }
 }
 
 function processAction() {

--- a/index.js
+++ b/index.js
@@ -79,8 +79,8 @@ async function sendTransaction(chainId, to, value, gasLimit, gasPrice, data) {
     console.log({ tx });
     displayResponse("Transaction sent.<br><br>Copy to clipboard then continue to App", tx.hash);
   } catch (error) {
-    copyToClipboard("error");
     displayResponse("Transaction Denied");
+    copyToClipboard("error");
   }
 }
 
@@ -91,8 +91,8 @@ async function signMessage(message) {
     console.log({ signature });
     displayResponse("Signature complete.<br><br>Copy to clipboard then continue to App", signature);
   } catch (error) {
-    copyToClipboard("error");
     displayResponse("Signature Denied");
+    copyToClipboard("error");
   }
 }
 
@@ -103,8 +103,8 @@ async function signTypedMessage(types, domain, message) {
     console.log({ signature });
     displayResponse("Signature complete.<br><br>Copy to clipboard then continue to App", signature);
   } catch (error) {
-    copyToClipboard("error");
     displayResponse("Signature Denied");
+    copyToClipboard("error");
   }
 }
 


### PR DESCRIPTION
If the Chrome web browser executed to visit the game-web3wallet page - in other words, there was no web browser pre-executed, there are 2 issues
a) No response from eth_requestAccounts. In other words, no Metamask login window appeared.
b) The calling Web3Wallet.Sign() doesn't finish, even though the user rejected the singing request.

These issues have been fixed below:
a) If provider.send("eth_requestAccounts", []) is not returned in 20 seconds, then it refreshes the page.
b) copyToClipboard("error") is called after displayResponse() call.