### PR TITLE
The Copy button was removed

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,6 +105,7 @@ async function copyToClipboard(response) {
     await new Promise((resolve) => setTimeout(resolve, 500));
     // copy tx hash to clipboard
     await navigator.clipboard.writeText(response);
+    document.getElementById("response-button").innerHTML = "Copied";
   } catch {
     // for metamask mobile android
     const input = document.createElement("input");
@@ -114,6 +115,29 @@ async function copyToClipboard(response) {
     input.select();
     document.execCommand("Copy");
     input.style = "visibility: hidden";
+    document.getElementById("response-button").innerHTML = "Copied";
+  }
+}
+
+async function getClipboardPermission() {
+  try {
+    const permissionState = await navigator.permissions.query({name: "clipboard-write"});
+    if (permissionState) return permissionState.state;
+  } catch {
+  }
+  return undefined;
+}
+
+async function writeToClipboard(response) {
+  if (await getClipboardPermission()) {
+    // document.execCommand(‘cut’/‘copy’) is allowed from outside a user-generated event handler as well.
+    copyToClipboard(response);
+  } else {
+    // In case of Firefox
+    // display button to copy tx.hash or signature
+    const responseButton = document.getElementById("response-button");
+    responseButton.className = "active";
+    responseButton.onclick = () => copyToClipboard(response);
   }
 }
 
@@ -124,6 +148,6 @@ function displayResponse(text, response) {
   responseText.className = "active";
 
   if (response) {
-    copyToClipboard(response);
+    writeToClipboard(response);
   }
 }

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ async function sendTransaction(chainId, to, value, gasLimit, gasPrice, data) {
       data: data ? data : "0x",
     });
     console.log({ tx });
-    displayResponse("Transaction sent.<br><br>Copy to clipboard then continue to App", tx.hash);
+    displayResponse("Transaction sent.", tx.hash);
   } catch (error) {
     copyToClipboard("error");
     displayResponse("Transaction Denied");
@@ -78,7 +78,7 @@ async function signMessage(message) {
     await new Promise((resolve) => setTimeout(resolve, 1000));
     const signature = await signer.signMessage(message);
     console.log({ signature });
-    displayResponse("Signature complete.<br><br>Copy to clipboard then continue to App", signature);
+    displayResponse("Signature complete.", signature);
   } catch (error) {
     copyToClipboard("error");
     displayResponse("Signature Denied");
@@ -90,7 +90,7 @@ async function signTypedMessage(types, domain, message) {
     await new Promise((resolve) => setTimeout(resolve, 1000));
     const signature = await signer._signTypedData(JSON.parse(domain), JSON.parse(types), JSON.parse(message))
     console.log({ signature });
-    displayResponse("Signature complete.<br><br>Copy to clipboard then continue to App", signature);
+    displayResponse("Signature complete.", signature);
   } catch (error) {
     copyToClipboard("error");
     displayResponse("Signature Denied");
@@ -105,7 +105,6 @@ async function copyToClipboard(response) {
     await new Promise((resolve) => setTimeout(resolve, 500));
     // copy tx hash to clipboard
     await navigator.clipboard.writeText(response);
-    document.getElementById("response-button").innerHTML = "Copied";
   } catch {
     // for metamask mobile android
     const input = document.createElement("input");
@@ -115,7 +114,6 @@ async function copyToClipboard(response) {
     input.select();
     document.execCommand("Copy");
     input.style = "visibility: hidden";
-    document.getElementById("response-button").innerHTML = "Copied";
   }
 }
 
@@ -126,9 +124,6 @@ function displayResponse(text, response) {
   responseText.className = "active";
 
   if (response) {
-    // display button to copy tx.hash or signature
-    const responseButton = document.getElementById("response-button");
-    responseButton.className = "active";
-    responseButton.onclick = () => copyToClipboard(response);
+    copyToClipboard(response);
   }
 }


### PR DESCRIPTION
Users don't want the double confirmation after approval on the Metamask wallet.
Therefore, the response will be instantly copied to the clipboard and the Copy button was removed.
The Copy button will appear on only Firefox.